### PR TITLE
[Phreeqc] std::ptr_fun deprecated.

### DIFF
--- a/src/phreeqcpp/common/Parser.h
+++ b/src/phreeqcpp/common/Parser.h
@@ -280,12 +280,12 @@ class CParser: public PHRQ_base
 // Global functions
 static inline std::string &trim_left(std::string &s)
 { 
-	s.erase(s.begin(), std::find_if(s.begin(), s.end(), std::not1(std::ptr_fun<int, int>(std::isspace)))); 
+    s.erase(s.begin(), std::find_if(s.begin(), s.end(), [](unsigned char c){ return !std::isspace(c); }));
 	return s; 
 } 
 static inline std::string &trim_right(std::string &s)
 { 
-	s.erase(std::find_if(s.rbegin(), s.rend(), std::not1(std::ptr_fun<int, int>(std::isspace))).base(), s.end()); 
+    s.erase(std::find_if(s.rbegin(), s.rend(), [](unsigned char c){ return !std::isspace(c); }).base(), s.end());
 	return s; 
 } 
 static inline std::string &trim(std::string &s)


### PR DESCRIPTION
As titled. This pull request is part of PR #2918.